### PR TITLE
removed obsolete 'use ebsco' permission

### DIFF
--- a/ebsco/ebsco.module
+++ b/ebsco/ebsco.module
@@ -92,9 +92,6 @@ function ebsco_permission() {
         'administer ebsco' => array(
             'title' => t('Administer EBSCO')
         ),
-        'use ebsco' => array(
-            'title' => t('Use EBSCO')
-        )
     );
 }
 


### PR DESCRIPTION
don't see it being used anywhere.

please review and merge if OK. thanks!