### PR TITLE
Trim title authors

### DIFF
--- a/ebsco/ebsco.module
+++ b/ebsco/ebsco.module
@@ -68,6 +68,10 @@ function ebsco_theme() {
     ),
     'ebsco_results' => array(
       'template' => 'templates/ebsco-results',
+      'variables' => array(
+        'trim_title' => FALSE,
+        'trim_authors' => FALSE,
+      ),
     ),
     'ebsco_side_facets' => array(
       'template' => 'templates/ebsco-side-facets',
@@ -216,6 +220,25 @@ function ebsco_admin() {
     '#required' => TRUE,
   );
 
+  $form['ebsco_general']['ebsco_title_trim'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Trim result Title'),
+    '#default_value' => variable_get('ebsco_title_trim', 0),
+    '#size' => 3,
+    '#maxlength' => 3,
+    '#description' => t('Title maximum number of characters to be displayed when an item is render in search result page.'),
+    '#required' => TRUE,
+  );
+
+  $form['ebsco_general']['ebsco_authors_trim'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Trim result Authors'),
+    '#default_value' => variable_get('ebsco_authors_trim', 0),
+    '#size' => 3,
+    '#maxlength' => 3,
+    '#description' => t('Authors maximum number of characters to be displayed when an item is render in search result page.'),
+    '#required' => TRUE,
+  );
   return system_settings_form($form);
 }
 
@@ -904,6 +927,9 @@ function template_preprocess_ebsco_results(&$variables) {
   $variables['relatedContent'] = $_ebsco_document->relatedContent();
   $variables['autoSuggestTerms'] = $_ebsco_document->autoSuggestTerms();
   $variables['lookfor'] = '';
+  $variables['trim_title'] = variable_get('ebsco_title_trim', 0);
+  $variables['trim_authors'] = variable_get('ebsco_authors_trim', 0);
+
   if (isset($params['lookfor'])) {
     $variables['lookfor'] = $params['lookfor'];
   }

--- a/ebsco/templates/ebsco-results.tpl.php
+++ b/ebsco/templates/ebsco-results.tpl.php
@@ -275,7 +275,7 @@
           echo "</p>";
         }
         elseif ($record->title){
-          echo '<a href="' . $recordUrl . '" class="title">' . $record->title . '</a>';
+          echo '<a href="' . $recordUrl . '" class="title _record_link">' . $record->title . '</a>';
         }
          ?>
       </div>
@@ -300,7 +300,7 @@
           echo '<cite>' . $record->summary . '</cite><br />';
         }
 
-        if (!empty($record->subjects) && !$hide_record_subject){
+        if (!empty($record->subjects)){
           echo '<strong>' . t('Subjects') . '</strong>:<span class="quotestart">' . str_replace('<br />', ', ', $record->subjects) . '</span>';
         }
 

--- a/ebsco/templates/ebsco-results.tpl.php
+++ b/ebsco/templates/ebsco-results.tpl.php
@@ -230,6 +230,16 @@
   <ol class="search-results ebsco">
   <?php foreach ($records as $record):
 
+    // Trim Title if needed.
+    if ($trim_title && strlen($record->title) > $trim_title) {
+      $record->title = truncate_utf8($record->title, $trim_title, TRUE, TRUE, 1);
+    }
+
+    // Trim Authors if needed.
+    if ($trim_authors && strlen($record->authors) > $trim_authors) {
+      $record->authors = truncate_utf8(implode(',',explode('<br />', $record->authors)), $trim_authors, TRUE, TRUE, 1);
+    }
+
     $id = check_plain($record->record_id());
     $recordUrl = url('ebsco/result', array('query' => array('id' => $id)));
     $fulltextUrl = url('ebsco/fulltext', array('query' => array('id' => $id)));
@@ -265,7 +275,7 @@
           echo "</p>";
         }
         elseif ($record->title){
-          echo '<a href="' . $recordUrl . '" class="title _record_link">' . $record->title . '</a>';
+          echo '<a href="' . $recordUrl . '" class="title">' . $record->title . '</a>';
         }
          ?>
       </div>
@@ -290,7 +300,7 @@
           echo '<cite>' . $record->summary . '</cite><br />';
         }
 
-        if (!empty($record->subjects)){
+        if (!empty($record->subjects) && !$hide_record_subject){
           echo '<strong>' . t('Subjects') . '</strong>:<span class="quotestart">' . str_replace('<br />', ', ', $record->subjects) . '</span>';
         }
 


### PR DESCRIPTION
This branch add logic to allow set custom trim to Author and Title fields. The changes only affect to ebsco-results.tpl.php that it is the main template.

The commits in this branch add:

* New fields in the admin UI to allow set the characters to trim
* Logic to pass the parameters to ebsco-results.tpl.php template
* Logic to apply the trim removing the <br /> tags
* Improve logic to display Authors. Now we use implode instead replace strings that was causing a problem because was adding "," at the end of the string.