### PR TITLE
Remove call to deprecated function

### DIFF
--- a/ebsco.module
+++ b/ebsco.module
@@ -1512,10 +1512,9 @@ function auto_link($string)
 {
     $linkedString = preg_replace_callback(
         "/\b(https?):\/\/([-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|]*)\b/i",
-        create_function(
-            '$matches',
-            'return "<a href=\'".($matches[0])."\'>".($matches[0])."</a>";'
-        ),
+        function ($matches) {
+          return "<a href='".($matches[0])."'>".($matches[0])."</a>";
+        },
         $string
     );
     return $linkedString;


### PR DESCRIPTION
This fixes issue #22 by replacing the call to deprecated function `create_function()` with an anonymous function that has the same effect.